### PR TITLE
Predict inventory list movement and add list_predict to formspec

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1264,6 +1264,7 @@ examples.
     size[8,9]
     list[context;fuel;2,3;1,1;]
     list[context;src;2,1;1,1;]
+    list_predict[all,0]
     list[context;dst;5,1;2,2;]
     list[current_player;main;0,5;8,4;]
 
@@ -1273,6 +1274,7 @@ examples.
     image[1,0.6;1,2;player.png]
     list[current_player;main;0,3.5;8,4;]
     list[current_player;craft;3,0;3,3;]
+    list_predict[all,0]
     list[current_player;craftpreview;7,1;1,1;]
 
 ### Elements
@@ -1287,6 +1289,11 @@ examples.
 
 #### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>]`
 * Show an inventory list
+
+#### `list_predict[<take_predict>,<put_predict>]
+* Predict how many items can be taken or put in the subsequent list[]
+* `take_predict`: `all`/integer >= 0
+* `put_predict`: `all`/integer >= 0
 
 #### `listcolors[<slot_bg_normal>;<slot_bg_hover>]`
 * Sets background color of slots as `ColorString`

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -126,7 +126,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PASSWORD_SIZE 28       // Maximum password length. Allows for
                                // base64-encoded SHA-1 (27+\0).
 
-#define FORMSPEC_API_VERSION 1
+#define FORMSPEC_API_VERSION 2
 #define FORMSPEC_VERSION_STRING "formspec_version[" TOSTRING(FORMSPEC_API_VERSION) "]"
 
 #define TEXTURENAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -74,6 +74,25 @@ public:
 
 class GUIFormSpecMenu : public GUIModalMenu
 {
+	/**
+	 * Stores client predction values
+	 */
+	struct ListPredict
+	{
+		int take;
+		int put;
+
+		ListPredict() {
+			take = DEFAULT_MAX_MOVE_INVENTORY_ITEMS;
+			put = DEFAULT_MAX_MOVE_INVENTORY_ITEMS;
+		}
+
+		ListPredict(int a_take, int a_put) {
+			take = a_take;
+			put = a_put;
+		}
+	};
+
 	struct ItemSpec
 	{
 		ItemSpec()
@@ -82,11 +101,13 @@ class GUIFormSpecMenu : public GUIModalMenu
 		}
 		ItemSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				s32 a_i)
+				s32 a_i,
+				ListPredict a_list_predict)
 		{
 			inventoryloc = a_inventoryloc;
 			listname = a_listname;
 			i = a_i;
+			list_predict = a_list_predict;
 		}
 		bool isValid() const
 		{
@@ -96,6 +117,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		InventoryLocation inventoryloc;
 		std::string listname;
 		s32 i;
+		ListPredict list_predict;
 	};
 
 	struct ListDrawSpec
@@ -105,12 +127,14 @@ class GUIFormSpecMenu : public GUIModalMenu
 		}
 		ListDrawSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i):
+				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i,
+				ListPredict a_list_predict):
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
 			pos(a_pos),
 			geom(a_geom),
-			start_item_i(a_start_item_i)
+			start_item_i(a_start_item_i),
+			list_predict(a_list_predict)
 		{
 		}
 
@@ -119,6 +143,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		v2s32 pos;
 		v2s32 geom;
 		s32 start_item_i;
+		ListPredict list_predict;
 	};
 
 	struct ImageDrawSpec
@@ -361,6 +386,7 @@ private:
 		GUITable::TableColumns table_columns;
 		// used to restore table selection/scroll/treeview state
 		std::map<std::wstring,GUITable::DynamicData> table_dyndata;
+		ListPredict list_predict;
 	} parserData;
 
 	typedef struct {
@@ -375,6 +401,7 @@ private:
 	void parseElement(parserData* data,std::string element);
 
 	void parseSize(parserData* data,std::string element);
+	void parseListPredict(parserData* data, std::string element);
 	void parseList(parserData* data,std::string element);
 	void parseCheckbox(parserData* data,std::string element);
 	void parseImage(parserData* data,std::string element);

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -121,6 +121,9 @@ public:
 #define IACTION_DROP 1
 #define IACTION_CRAFT 2
 
+// default maximum number of items that can be moved between inventories
+#define DEFAULT_MAX_MOVE_INVENTORY_ITEMS 65535
+
 struct InventoryAction
 {
 	static InventoryAction * deSerialize(std::istream &is);
@@ -143,6 +146,9 @@ struct IMoveAction : public InventoryAction
 	InventoryLocation to_inv;
 	std::string to_list;
 	s16 to_i;
+	// take_predict and put_predict are calculated and used on the client only
+	int take_predict;
+	int put_predict;
 	
 	IMoveAction()
 	{
@@ -182,6 +188,8 @@ struct IDropAction : public InventoryAction
 	InventoryLocation from_inv;
 	std::string from_list;
 	s16 from_i;
+	// take_predict is calculated and used on the client only
+	int take_predict;
 	
 	IDropAction()
 	{


### PR DESCRIPTION
list_predict can be used for mods to customize the list movement
prediction. The format is list_predict[<take predict>,<put predict>].
'all' means to allow the entire stack to move and is the default if
list_predict is not present.
